### PR TITLE
Do not export the native content of a Hyva managed entity

### DIFF
--- a/Model/Service/DumpCmsDataService.php
+++ b/Model/Service/DumpCmsDataService.php
@@ -177,9 +177,13 @@ class DumpCmsDataService
                 $identifier = str_replace('.html', '_html', $identifier);
             }
 
+            $hyvaData = $hyvaCms && $this->hyvaContentReader->isAvailable()
+                ? $this->hyvaContentReader->readPage((int)$page->getId())
+                : null;
+
             $storeCodes = $this->getStoreCodes($page->getStores());
             $htmlPath = $path . $identifier . '---' . implode('---', $storeCodes) . '.html';
-            $pageContent = $this->replaceBlockIds($page->getContent());
+            $pageContent = $hyvaData === null ? $this->replaceBlockIds($page->getContent()) : '';
             $this->write($varDirectory, $htmlPath, $pageContent);
             $jsonPath = $path . $identifier . '---' . implode('---', $storeCodes) . '.json';
             $jsonContent = [
@@ -195,13 +199,10 @@ class DumpCmsDataService
                 $jsonContent['is_tailwindcss_jit_enabled'] = $page->getIsTailwindcssJitEnabled();
             }
             $this->write($varDirectory, $jsonPath, $this->serializer->serialize($jsonContent));
-            if ($hyvaCms && $this->hyvaContentReader->isAvailable()) {
-                $hyvaData = $this->hyvaContentReader->readPage((int)$page->getId());
-                if ($hyvaData !== null) {
-                    $this->warnOnLargeCss($identifier, $hyvaData['tailwindcss']);
-                    $hyvaPath = $path . $identifier . '---' . implode('---', $storeCodes) . '.hyva.json';
-                    $this->write($varDirectory, $hyvaPath, $this->serializer->serialize($hyvaData));
-                }
+            if ($hyvaData !== null) {
+                $this->warnOnLargeCss($identifier, $hyvaData['tailwindcss']);
+                $hyvaPath = $path . $identifier . '---' . implode('---', $storeCodes) . '.hyva.json';
+                $this->write($varDirectory, $hyvaPath, $this->serializer->serialize($hyvaData));
             }
         }
     }
@@ -228,9 +229,13 @@ class DumpCmsDataService
                 continue;
             }
             $this->blockIdentifiers[$block->getId()] = $block->getIdentifier();
+            $hyvaData = $hyvaCms && $this->hyvaContentReader->isAvailable()
+                ? $this->hyvaContentReader->readBlock((int)$block->getId())
+                : null;
+
             $storeCodes = $this->getStoreCodes($block->getStores());
             $htmlPath = $path . trim($block->getIdentifier()) . '---' . implode('---', $storeCodes) . '.html';
-            $this->write($varDirectory, $htmlPath, $block->getContent());
+            $this->write($varDirectory, $htmlPath, $hyvaData === null ? $block->getContent() : '');
             $jsonPath = $path . trim($block->getIdentifier()) . '---' . implode('---', $storeCodes) . '.json';
             $jsonContent = [
                 'title' => $block->getTitle(),
@@ -242,14 +247,11 @@ class DumpCmsDataService
                 $jsonContent['is_tailwindcss_jit_enabled'] = $block->getIsTailwindcssJitEnabled();
             }
             $this->write($varDirectory, $jsonPath, $this->serializer->serialize($jsonContent));
-            if ($hyvaCms && $this->hyvaContentReader->isAvailable()) {
-                $hyvaData = $this->hyvaContentReader->readBlock((int)$block->getId());
-                if ($hyvaData !== null) {
-                    $this->warnOnLargeCss(trim($block->getIdentifier()), $hyvaData['tailwindcss']);
-                    $hyvaPath = $path . trim($block->getIdentifier())
-                        . '---' . implode('---', $storeCodes) . '.hyva.json';
-                    $this->write($varDirectory, $hyvaPath, $this->serializer->serialize($hyvaData));
-                }
+            if ($hyvaData !== null) {
+                $this->warnOnLargeCss(trim($block->getIdentifier()), $hyvaData['tailwindcss']);
+                $hyvaPath = $path . trim($block->getIdentifier())
+                    . '---' . implode('---', $storeCodes) . '.hyva.json';
+                $this->write($varDirectory, $hyvaPath, $this->serializer->serialize($hyvaData));
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -167,6 +167,19 @@ The payload carries:
 `references` is diagnostic only. Nothing reads it back on import: the importer re-derives the references from the
 content it actually imported and checks those, so a hand edited file cannot lie about its own dependencies.
 
+### The native content is not exported for a Hyva entity
+
+When `--hyva-cms` is on and an entity is Hyva managed, its `.html` is written empty. The component tree in the
+`.hyva.json` is what the storefront renders, so `cms_page.content` and `cms_block.content` are either empty
+already or left over from whatever built the page before Hyva CMS did. Carrying that is pure weight: six real
+pages in one project held 224 KB of stale HTML against 96 KB of live Hyva content.
+
+The file itself still has to exist, because the importer discovers entities by their `.html`. An entity that is
+not Hyva managed keeps its content as before, flag or no flag, and so does every entity when Hyva CMS is absent.
+
+Import mirrors the source, so promoting a Hyva page clears the native content on the target. That is the intended
+result. If a target holds legacy HTML you want to keep, do not promote that entity.
+
 ### Which Tailwind CSS travels
 
 Hyva CMS writes several `*_tailwindcss` tables. Only the ones a storefront request reads are exported.

--- a/Test/Integration/HyvaCms/HyvaCmsAbsentTest.php
+++ b/Test/Integration/HyvaCms/HyvaCmsAbsentTest.php
@@ -168,6 +168,30 @@ class HyvaCmsAbsentTest extends TestCase
     }
 
     /**
+     * The native content is only redundant for an entity Hyva CMS actually renders. With Hyva absent nothing is
+     * Hyva managed, so every .html has to keep carrying the content it always did.
+     *
+     * @throws FileSystemException
+     * @magentoDataFixture Magento/Cms/_files/block.php
+     * @magentoDataFixture Magento/Cms/_files/noroute.php
+     */
+    public function testNativeContentIsKeptWhenHyvaCmsIsAbsent(): void
+    {
+        $this->exporter->execute(['block', 'page'], null, true, true);
+
+        $htmlFiles = array_filter(
+            $this->readExportTree(),
+            static fn (string $path): bool => str_ends_with($path, '.html'),
+            ARRAY_FILTER_USE_KEY
+        );
+
+        $this->assertNotEmpty($htmlFiles, 'The fixtures must produce html files, or this proves nothing.');
+        foreach ($htmlFiles as $path => $contents) {
+            $this->assertNotSame('', $contents, "$path lost its native content");
+        }
+    }
+
+    /**
      * @return array<string, string> relative path to contents, sorted so comparisons are order independent
      * @throws FileSystemException
      */


### PR DESCRIPTION
When `--hyva-cms` is on, the `.html` sibling of a Hyva managed page or block is written empty.

The component tree in the `.hyva.json` is what renders. The native `content` column is either already empty or stale legacy markup. On the CENVEO CMS store six pages carried 224KB of dead HTML against 96KB of live Hyva content.

The `.html` file is still written, because the importer discovers entities by it.

Unchanged: entities that are not Hyva managed, and every entity when Hyva CMS is absent. The off path stays byte identical, re-verified with a full `diff -r` against 1.3.0.