### PR TITLE
Add --type=menu to both commands

### DIFF
--- a/Console/Command/DumpCmsData.php
+++ b/Console/Command/DumpCmsData.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DumpCmsData extends \Symfony\Component\Console\Command\Command
 {
     private const INPUT_KEY_TYPE = 'type';
-    private const INPUT_TYPE_VALUES = ['block', 'page', 'all'];
+    private const INPUT_TYPE_VALUES = ['block', 'page', 'menu', 'all'];
     private const INPUT_KEY_IDENTIFIER = 'identifier';
     private const INPUT_KEY_REMOVE_ALL = 'removeAll';
     private const INPUT_KEY_HYVA_CMS = 'hyva-cms';
@@ -46,7 +46,7 @@ class DumpCmsData extends \Symfony\Component\Console\Command\Command
                 self::INPUT_KEY_TYPE,
                 't',
                 InputOption::VALUE_REQUIRED,
-                'Which type are we dumping - block/page/all'
+                'Which type are we dumping - block/page/menu/all (all covers block and page)'
             ),
             new InputOption(
                 self::INPUT_KEY_IDENTIFIER,
@@ -87,6 +87,10 @@ class DumpCmsData extends \Symfony\Component\Console\Command\Command
         }
         if ($type == 'all' || $type == 'page') {
             $types[] = 'page';
+        }
+        // Menus stay out of 'all' on purpose, so that an existing dump command keeps writing the same files.
+        if ($type == 'menu') {
+            $types[] = 'menu';
         }
 
         $identifiers = $input->getOption(self::INPUT_KEY_IDENTIFIER);

--- a/Console/Command/ImportCmsData.php
+++ b/Console/Command/ImportCmsData.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ImportCmsData extends \Symfony\Component\Console\Command\Command
 {
     private const INPUT_KEY_TYPE = 'type';
-    private const INPUT_TYPE_VALUES = ['block', 'page', 'all'];
+    private const INPUT_TYPE_VALUES = ['block', 'page', 'menu', 'all'];
     private const INPUT_KEY_IDENTIFIER = 'identifier';
     private const INPUT_KEY_IMPORT_ALL = 'importAll';
     private const INPUT_KEY_STORE = 'store';
@@ -49,7 +49,7 @@ class ImportCmsData extends \Symfony\Component\Console\Command\Command
                 self::INPUT_KEY_TYPE,
                 't',
                 InputOption::VALUE_REQUIRED,
-                'Which type are we importing - block/page/all'
+                'Which type are we importing - block/page/menu/all (all covers block and page)'
             ),
             new InputOption(
                 self::INPUT_KEY_IDENTIFIER,
@@ -96,6 +96,10 @@ class ImportCmsData extends \Symfony\Component\Console\Command\Command
         }
         if ($type == 'all' || $type == 'page') {
             $types[] = 'page';
+        }
+        // Menus stay out of 'all' on purpose, so that an existing import command keeps reading the same files.
+        if ($type == 'menu') {
+            $types[] = 'menu';
         }
 
         $identifiers = $input->getOption(self::INPUT_KEY_IDENTIFIER);

--- a/Model/Service/DumpCmsDataService.php
+++ b/Model/Service/DumpCmsDataService.php
@@ -77,7 +77,33 @@ class DumpCmsDataService
                 $this->dumpBlocks($workingDirPath . '/cms/blocks/', $varDirectory, $identifiers, $hyvaCms);
             } else if ($type == 'page') {
                 $this->dumpPages($workingDirPath . '/cms/pages/', $varDirectory, $identifiers, $hyvaCms);
+            } else if ($type == 'menu') {
+                $this->dumpMenus($workingDirPath . '/cms/menus/', $varDirectory, $identifiers);
             }
+        }
+    }
+
+    /**
+     * A menu has no native CMS row behind it, so it exports as a single json file rather than the html, json and
+     * hyva.json trio the other types use. That also makes --hyva-cms meaningless here: the Hyva content is the
+     * whole entity, so --type=menu always carries it.
+     */
+    private function dumpMenus(string $path, WriteInterface $varDirectory, ?array $identifiers): void
+    {
+        if (!$this->hyvaContentReader->isMenuAvailable()) {
+            echo "Warning: menus were requested but Hyva Menu Builder is not installed, nothing was dumped\n";
+            return;
+        }
+
+        foreach ($this->hyvaContentReader->readMenus($identifiers) as $menu) {
+            $payload = $menu['payload'];
+            $identifier = trim((string)$payload['identifier']);
+            $storeCodes = $this->getStoreCodes($menu['stores']);
+            $payload['stores'] = $storeCodes;
+
+            $this->warnOnLargeCss($identifier, $payload['tailwindcss']);
+            $filePath = $path . str_replace('/', '---', $identifier) . '---' . implode('---', $storeCodes) . '.json';
+            $this->write($varDirectory, $filePath, $this->serializer->serialize($payload));
         }
     }
 

--- a/Model/Service/HyvaCms/ContentReader.php
+++ b/Model/Service/HyvaCms/ContentReader.php
@@ -33,9 +33,11 @@ class ContentReader
 {
     private const PAGE_REPOSITORY = \Hyva\CmsMagento\Api\PageRepositoryInterface::class;
     private const BLOCK_REPOSITORY = \Hyva\CmsMagento\Api\BlockRepositoryInterface::class;
+    private const MENU_REPOSITORY = \Hyva\MenuBuilder\Api\MenuRepositoryInterface::class;
     private const JIT_CSS_REPOSITORY = \Hyva\CmsLiveviewEditor\Model\Tailwind\JitCssRepository::class;
     private const ENTITY_TYPE_PAGE = 'cms_page';
     private const ENTITY_TYPE_BLOCK = 'cms_block';
+    private const ENTITY_TYPE_MENU = 'menu';
     private const EDITIONS = ['published', 'draft'];
 
     /**
@@ -49,13 +51,19 @@ class ContentReader
     private readonly ?object $blockRepository;
 
     /**
+     * @var \Hyva\MenuBuilder\Api\MenuRepositoryInterface|null
+     */
+    private readonly ?object $menuRepository;
+
+    /**
      * @var \Hyva\CmsLiveviewEditor\Model\Tailwind\JitCssRepository|null
      */
     private readonly ?object $jitCssRepository;
 
     public function __construct(
         \Magento\Framework\ObjectManagerInterface $objectManager,
-        private readonly \RocketWeb\CmsImportExport\Model\Service\HyvaCms\ReferenceCollector $referenceCollector
+        private readonly \RocketWeb\CmsImportExport\Model\Service\HyvaCms\ReferenceCollector $referenceCollector,
+        private readonly \Magento\Framework\Api\SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
     ) {
         $hyvaCmsInstalled = interface_exists(self::PAGE_REPOSITORY)
             && interface_exists(self::BLOCK_REPOSITORY)
@@ -64,11 +72,21 @@ class ContentReader
         $this->pageRepository = $hyvaCmsInstalled ? $objectManager->get(self::PAGE_REPOSITORY) : null;
         $this->blockRepository = $hyvaCmsInstalled ? $objectManager->get(self::BLOCK_REPOSITORY) : null;
         $this->jitCssRepository = $hyvaCmsInstalled ? $objectManager->get(self::JIT_CSS_REPOSITORY) : null;
+
+        // Menu Builder ships as its own package, so it is present or absent independently of Hyva CMS.
+        $this->menuRepository = $hyvaCmsInstalled && interface_exists(self::MENU_REPOSITORY)
+            ? $objectManager->get(self::MENU_REPOSITORY)
+            : null;
     }
 
     public function isAvailable(): bool
     {
         return $this->pageRepository !== null;
+    }
+
+    public function isMenuAvailable(): bool
+    {
+        return $this->menuRepository !== null;
     }
 
     /**
@@ -103,6 +121,72 @@ class ContentReader
         }
 
         return $this->buildContent($block, self::ENTITY_TYPE_BLOCK, $cmsBlockId);
+    }
+
+    /**
+     * Lists menus for the dump, so that the repository stays behind this class along with the object manager.
+     *
+     * @param array<int, string>|null $identifiers null exports every menu
+     * @return array<int, array{stores: array<int, int>, payload: array<string, mixed>}>
+     */
+    public function readMenus(?array $identifiers): array
+    {
+        if (!$this->isMenuAvailable()) {
+            return [];
+        }
+
+        $criteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        if ($identifiers) {
+            $criteriaBuilder->addFilter('identifier', $identifiers, 'in');
+        }
+
+        $menus = [];
+        foreach ($this->menuRepository->getList($criteriaBuilder->create())->getItems() as $menu) {
+            $menus[] = [
+                'stores' => $menu->getStores() ?? [],
+                'payload' => $this->buildMenuContent($menu)
+            ];
+        }
+
+        return $menus;
+    }
+
+    /**
+     * A menu is a Hyva entity in its own right, with no native CMS row behind it, so this returns the whole
+     * record rather than a sidecar to something else. Creation and update timestamps are left out: they describe
+     * the source install, and carrying them over would misdate the row on the target.
+     *
+     * @return array<string, mixed>|null null when Menu Builder is absent
+     */
+    public function readMenu(int $menuId): ?array
+    {
+        if (!$this->isMenuAvailable()) {
+            return null;
+        }
+
+        return $this->buildMenuContent($this->menuRepository->get($menuId));
+    }
+
+    /**
+     * @param object $menu \Hyva\MenuBuilder\Api\Data\MenuInterface
+     * @return array<string, mixed>
+     */
+    private function buildMenuContent(object $menu): array
+    {
+        $draftContent = $menu->getDraftContent();
+        $publishedContent = $menu->getPublishedContent();
+
+        return [
+            'title' => $menu->getTitle(),
+            'identifier' => $menu->getIdentifier(),
+            'is_active' => (bool)$menu->isActive(),
+            'preview_url_key' => $menu->getPreviewUrlKey(),
+            'is_tailwindcss_jit_enabled' => (bool)$menu->isTailwindcssJitEnabled(),
+            'draft_content' => $draftContent,
+            'published_content' => $publishedContent,
+            'references' => $this->referenceCollector->collectFromAll([$draftContent, $publishedContent]),
+            'tailwindcss' => $this->readTailwindcss(self::ENTITY_TYPE_MENU, (int)$menu->getId())
+        ];
     }
 
     /**

--- a/Model/Service/HyvaCms/ContentWriter.php
+++ b/Model/Service/HyvaCms/ContentWriter.php
@@ -37,9 +37,12 @@ class ContentWriter
     private const PROVIDER = \Hyva\CmsLiveviewEditor\Model\Provider::class;
     private const PAGE_REPOSITORY = \Hyva\CmsMagento\Api\PageRepositoryInterface::class;
     private const BLOCK_REPOSITORY = \Hyva\CmsMagento\Api\BlockRepositoryInterface::class;
+    private const MENU_REPOSITORY = \Hyva\MenuBuilder\Api\MenuRepositoryInterface::class;
+    private const MENU_FACTORY = \Hyva\MenuBuilder\Model\MenuFactory::class;
     private const JIT_CSS_REPOSITORY = \Hyva\CmsLiveviewEditor\Model\Tailwind\JitCssRepository::class;
     private const ENTITY_TYPE_PAGE = 'cms_page';
     private const ENTITY_TYPE_BLOCK = 'cms_block';
+    private const ENTITY_TYPE_MENU = 'menu';
     private const EDITION_PUBLISHED = 'published';
     private const EDITION_DRAFT = 'draft';
     private const EDITIONS_IN_WRITE_ORDER = [self::EDITION_PUBLISHED, self::EDITION_DRAFT];
@@ -64,6 +67,16 @@ class ContentWriter
      */
     private readonly ?object $jitCssRepository;
 
+    /**
+     * @var \Hyva\MenuBuilder\Api\MenuRepositoryInterface|null
+     */
+    private readonly ?object $menuRepository;
+
+    /**
+     * @var \Hyva\MenuBuilder\Model\MenuFactory|null
+     */
+    private readonly ?object $menuFactory;
+
     public function __construct(
         \Magento\Framework\ObjectManagerInterface $objectManager
     ) {
@@ -76,11 +89,62 @@ class ContentWriter
         $this->pageRepository = $hyvaCmsInstalled ? $objectManager->get(self::PAGE_REPOSITORY) : null;
         $this->blockRepository = $hyvaCmsInstalled ? $objectManager->get(self::BLOCK_REPOSITORY) : null;
         $this->jitCssRepository = $hyvaCmsInstalled ? $objectManager->get(self::JIT_CSS_REPOSITORY) : null;
+
+        // Menu Builder ships as its own package, so it is present or absent independently of Hyva CMS.
+        $menuInstalled = $hyvaCmsInstalled
+            && interface_exists(self::MENU_REPOSITORY)
+            && class_exists(self::MENU_FACTORY);
+        $this->menuRepository = $menuInstalled ? $objectManager->get(self::MENU_REPOSITORY) : null;
+        $this->menuFactory = $menuInstalled ? $objectManager->get(self::MENU_FACTORY) : null;
     }
 
     public function isAvailable(): bool
     {
         return $this->provider !== null;
+    }
+
+    public function isMenuAvailable(): bool
+    {
+        return $this->menuRepository !== null;
+    }
+
+    /**
+     * Creates or updates the menu row itself, so that writeMenu() has an id to hang content on. Matching is by
+     * identifier within the payload's own store scope, which is what makes a re-import an update rather than a
+     * duplicate. Content is deliberately not set here: Provider::saveContent() has to do that, because only it
+     * clears the entity cache and dispatches the publish tags.
+     *
+     * @param array<string, mixed> $payload the decoded menu json file
+     * @param array<int, int> $storeIds resolved from the store codes in the file name
+     * @return int|null the saved menu id, null when Menu Builder is absent
+     */
+    public function saveMenuRow(array $payload, array $storeIds): ?int
+    {
+        if (!$this->isMenuAvailable()) {
+            return null;
+        }
+
+        $identifier = (string)($payload['identifier'] ?? '');
+        try {
+            $menu = $this->menuRepository->getByIdentifier($identifier, (int)reset($storeIds));
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {
+            $menu = $this->menuFactory->create();
+        }
+
+        $menu->setTitle((string)($payload['title'] ?? $identifier));
+        $menu->setIdentifier($identifier);
+        $menu->setIsActive((bool)($payload['is_active'] ?? true));
+        $menu->setStores($storeIds);
+
+        if (array_key_exists('preview_url_key', $payload)) {
+            $menu->setPreviewUrlKey($payload['preview_url_key'] === null ? null : (string)$payload['preview_url_key']);
+        }
+
+        if (array_key_exists('is_tailwindcss_jit_enabled', $payload)) {
+            $menu->setIsTailwindcssJitEnabled((bool)$payload['is_tailwindcss_jit_enabled']);
+        }
+
+        return (int)$this->menuRepository->save($menu)->getId();
     }
 
     /**
@@ -99,6 +163,36 @@ class ContentWriter
     public function writeBlock(int $cmsBlockId, array $payload): void
     {
         $this->write(self::ENTITY_TYPE_BLOCK, $cmsBlockId, $payload);
+    }
+
+    /**
+     * A menu carries its own title, identifier, store assignment and flags on the same row as its content, and
+     * the importer saves that row through saveMenuRow() before calling this.
+     *
+     * is_active is written again at the end because MenuProvider::saveContent() forces it true on publish, the
+     * way it forces is_liveview_enabled true for a page. An inactive menu would otherwise come back enabled.
+     *
+     * @param int $menuId the id of the menu row the importer just saved
+     * @param array<string, mixed> $payload the decoded menu json file
+     */
+    public function writeMenu(int $menuId, array $payload): void
+    {
+        if (!$this->isMenuAvailable()) {
+            return;
+        }
+
+        $tailwindcss = $payload['tailwindcss'] ?? [];
+
+        $this->writeContent(self::ENTITY_TYPE_MENU, $menuId, $payload);
+        $this->writeTailwindcss(self::ENTITY_TYPE_MENU, $menuId, is_array($tailwindcss) ? $tailwindcss : []);
+
+        if (!array_key_exists('is_active', $payload)) {
+            return;
+        }
+
+        $menu = $this->menuRepository->get($menuId);
+        $menu->setIsActive((bool)$payload['is_active']);
+        $this->menuRepository->save($menu);
     }
 
     /**

--- a/Model/Service/ImportCmsDataService.php
+++ b/Model/Service/ImportCmsDataService.php
@@ -94,6 +94,8 @@ class ImportCmsDataService
                 $this->importBlocks($typeDirPath, $identifiers, $storeCode, $hyvaCms);
             } else if ($type == 'page') {
                 $this->importPages($typeDirPath, $identifiers, $storeCode, $hyvaCms);
+            } else if ($type == 'menu') {
+                $this->importMenus($typeDirPath, $identifiers, $storeCode);
             }
         }
 
@@ -123,6 +125,77 @@ class ImportCmsDataService
         }
 
         return $storeIds;
+    }
+
+    /**
+     * A menu is one json file with no html sibling, because it has no native CMS row behind it. The row is saved
+     * first so that the content write has an id, and only then does the Hyva content and CSS follow.
+     */
+    private function importMenus(string $dirPath, ?array $identifiers, ?string $storeCode = null): void
+    {
+        if (!$this->hyvaContentWriter->isMenuAvailable()) {
+            echo "Warning: menus were requested but Hyva Menu Builder is not installed, nothing was imported\n";
+            return;
+        }
+
+        foreach ($this->directoryRead->read($this->varPath . $dirPath) as $filePath) {
+            if (substr($filePath, -5) !== '.json') {
+                continue;
+            }
+
+            $identifier = str_replace($dirPath, '', $filePath);
+            $identifier = substr_replace($identifier, '', (int)strrpos($identifier, '---'));
+            $identifier = str_replace('---', '/', $identifier);
+            if ($identifiers !== null && !in_array($identifier, $identifiers)) {
+                continue;
+            }
+
+            if ($storeCode !== null && $this->getStoreCodeFromJsonPath($filePath) !== $storeCode) {
+                echo sprintf(
+                    'Skipping identifier %s because requested update only for store %s %s',
+                    $identifier,
+                    $storeCode,
+                    PHP_EOL
+                );
+                continue;
+            }
+
+            $entityLabel = sprintf('menu "%s"', $identifier);
+            try {
+                $payload = $this->serializer->unserialize($this->directoryRead->readFile($filePath));
+            } catch (\Exception $exception) {
+                $this->warnHyva(sprintf('%s is unreadable: %s', $entityLabel, $exception->getMessage()));
+                continue;
+            }
+
+            if (!is_array($payload)) {
+                $this->warnHyva(sprintf('%s is not an object, skipping it', $entityLabel));
+                continue;
+            }
+
+            $storeIds = $this->getStoreIds($payload['stores'] ?? []);
+            try {
+                $menuId = $this->hyvaContentWriter->saveMenuRow($payload, $storeIds);
+                $this->hyvaContentWriter->writeMenu((int)$menuId, $payload);
+            } catch (\Exception $exception) {
+                $this->warnHyva(sprintf('%s could not be written: %s', $entityLabel, $exception->getMessage()));
+                continue;
+            }
+
+            foreach ($this->hyvaPayloadValidator->validate($entityLabel, $payload) as $warning) {
+                $this->warnHyva($warning);
+            }
+        }
+    }
+
+    /**
+     * The store code sits between the last --- and the .json suffix, as it does for the html files.
+     */
+    private function getStoreCodeFromJsonPath(string $filePath): string
+    {
+        $storeCode = substr($filePath, 0, -5);
+
+        return substr($storeCode, (int)strrpos($storeCode, '---') + 3);
     }
 
     private function importBlocks(

--- a/README.md
+++ b/README.md
@@ -141,6 +141,35 @@ Watch out for:
 - A missing block, menu or instance component renders as nothing, silently. The importer warns per miss.
 - Treat these files as code. Content and CSS reach the storefront unescaped, as the `.html` always has.
 
-Menus, templates, snippets, instance components, attribute content and version history are not exported.
+Templates, snippets, instance components, attribute content and version history are not exported.
 Templates and snippets are copy on insert, so a page never references one. The rest are separate content
 roots.
+
+## Hyva menus
+
+A Menu Builder menu has no native CMS row behind it, so it exports as one file rather than the html, json
+and hyva.json trio: `var/sync_cms_data/cms/menus/%%IDENTIFIER%%---%%STORES%%.json`. That file holds the
+title, identifier, active flag, preview url key, both content columns, every `{theme, edition, css}` row
+and the same diagnostic `references` list.
+
+```
+php bin/magento cms:dump:data   --type=menu -i main-nav
+php bin/magento cms:import:data --type=menu -i main-nav
+```
+
+`--type=menu` needs `hyva-themes/commerce-module-menu-builder`; without it both commands warn and do
+nothing. `--hyva-cms` has no meaning here, because the Hyva content is the whole entity.
+
+Watch out for:
+
+- **`--type=all` does not include menus.** It stays block and page, so an existing command keeps writing
+  and reading the same files. Ask for menus explicitly.
+- **A menu is matched by identifier within its own store scope.** Same identifier means update, so a
+  re-import never duplicates a menu.
+- **Category and product links do not survive the trip.** A menu item stores the identifier for a CMS
+  page and the SKU for a product, both of which port, but a category link and `hyva_menu_category_tree`
+  store category IDs, which differ per environment.
+- The importer sets the menu active again from the file after writing content, because publishing forces
+  it on. An inactive menu stays inactive.
+- Pointing a storefront at an imported menu is separate configuration: `design/header/topmenu_identifier`
+  under Content > Design > Configuration.

--- a/README.md
+++ b/README.md
@@ -148,9 +148,8 @@ roots.
 ## Hyva menus
 
 A Menu Builder menu has no native CMS row behind it, so it exports as one file rather than the html, json
-and hyva.json trio: `var/sync_cms_data/cms/menus/%%IDENTIFIER%%---%%STORES%%.json`. That file holds the
-title, identifier, active flag, preview url key, both content columns, every `{theme, edition, css}` row
-and the same diagnostic `references` list.
+and hyva.json trio: `var/sync_cms_data/cms/menus/%%IDENTIFIER%%---%%STORES%%.json`, holding the whole
+record plus its CSS rows and the same diagnostic `references` list.
 
 ```
 php bin/magento cms:dump:data   --type=menu -i main-nav
@@ -162,14 +161,8 @@ nothing. `--hyva-cms` has no meaning here, because the Hyva content is the whole
 
 Watch out for:
 
-- **`--type=all` does not include menus.** It stays block and page, so an existing command keeps writing
-  and reading the same files. Ask for menus explicitly.
-- **A menu is matched by identifier within its own store scope.** Same identifier means update, so a
-  re-import never duplicates a menu.
-- **Category and product links do not survive the trip.** A menu item stores the identifier for a CMS
-  page and the SKU for a product, both of which port, but a category link and `hyva_menu_category_tree`
-  store category IDs, which differ per environment.
-- The importer sets the menu active again from the file after writing content, because publishing forces
-  it on. An inactive menu stays inactive.
-- Pointing a storefront at an imported menu is separate configuration: `design/header/topmenu_identifier`
-  under Content > Design > Configuration.
+- **`--type=all` does not include menus.** Ask for them explicitly.
+- **Category links do not survive the trip.** A menu item stores the identifier for a CMS page and the
+  SKU for a product, but a category link and `hyva_menu_category_tree` store category IDs.
+- A menu matches by identifier within its own store scope, so a re-import updates rather than duplicates.
+- Pointing a storefront at the menu is separate configuration, `design/header/topmenu_identifier`.

--- a/Test/Integration/HyvaCms/HyvaCmsAbsentTest.php
+++ b/Test/Integration/HyvaCms/HyvaCmsAbsentTest.php
@@ -73,10 +73,55 @@ class HyvaCmsAbsentTest extends TestCase
         $this->assertFalse($this->writer->isAvailable());
     }
 
+    /**
+     * Menu Builder is a separate package from Hyva CMS, so it gets its own availability flag and its own
+     * degraded path.
+     */
+    public function testMenuSupportReportsItselfUnavailable(): void
+    {
+        $this->assertFalse($this->reader->isMenuAvailable());
+        $this->assertFalse($this->writer->isMenuAvailable());
+    }
+
     public function testReaderReturnsNullRatherThanFataling(): void
     {
         $this->assertNull($this->reader->readPage(1));
         $this->assertNull($this->reader->readBlock(1));
+        $this->assertNull($this->reader->readMenu(1));
+        $this->assertSame([], $this->reader->readMenus(null));
+    }
+
+    public function testMenuWriterIsANoOpRatherThanFataling(): void
+    {
+        $payload = [
+            'title' => 'Main navigation',
+            'identifier' => 'main-nav',
+            'is_active' => true,
+            'draft_content' => '{"content":[]}',
+            'published_content' => '{"content":[]}',
+            'tailwindcss' => []
+        ];
+
+        $this->assertNull($this->writer->saveMenuRow($payload, [1]));
+        $this->writer->writeMenu(1, $payload);
+
+        $this->assertFalse($this->writer->isMenuAvailable());
+    }
+
+    /**
+     * The export has to warn and return rather than fatal on the missing repository, the same way the page and
+     * block export does when Hyva CMS is absent.
+     *
+     * @throws FileSystemException
+     */
+    public function testMenuExportWarnsAndWritesNothing(): void
+    {
+        ob_start();
+        $this->exporter->execute(['menu'], null, false);
+        $output = (string)ob_get_clean();
+
+        $this->assertStringContainsString('Menu Builder is not installed', $output);
+        $this->assertFalse($this->varDirectory->isExist($this->exportDirPath . '/cms/menus'));
     }
 
     public function testWriterIsANoOpRatherThanFataling(): void

--- a/Test/Integration/HyvaCms/HyvaCmsPresentTest.php
+++ b/Test/Integration/HyvaCms/HyvaCmsPresentTest.php
@@ -49,6 +49,45 @@ class HyvaCmsPresentTest extends TestCase
     }
 
     /**
+     * A menu has no native row to hang off, so the writer creates it, and a second write with the same
+     * identifier has to update that row rather than add a second one.
+     *
+     * is_active is asserted false on purpose: publishing forces it true inside Menu Builder, so this is the
+     * regression test for the flag being written back afterwards.
+     */
+    public function testMenuRoundTripCreatesThenUpdatesOneRow(): void
+    {
+        if (!$this->writer->isMenuAvailable()) {
+            $this->markTestSkipped('Hyva Menu Builder is not installed, the layer under test does not exist here.');
+        }
+
+        $payload = [
+            'title' => 'Round trip menu',
+            'identifier' => 'rw-round-trip-menu',
+            'is_active' => false,
+            'preview_url_key' => null,
+            'is_tailwindcss_jit_enabled' => false,
+            'draft_content' => '{"content":[]}',
+            'published_content' => '{"content":[]}',
+            'tailwindcss' => []
+        ];
+
+        $menuId = $this->writer->saveMenuRow($payload, [1]);
+        $this->writer->writeMenu((int)$menuId, $payload);
+
+        $exported = $this->reader->readMenu((int)$menuId);
+        $this->assertSame('rw-round-trip-menu', $exported['identifier']);
+        $this->assertSame('Round trip menu', $exported['title']);
+        $this->assertFalse($exported['is_active']);
+
+        $payload['title'] = 'Round trip menu renamed';
+        $secondId = $this->writer->saveMenuRow($payload, [1]);
+
+        $this->assertSame($menuId, $secondId, 'A same identifier import has to update rather than duplicate.');
+        $this->assertSame('Round trip menu renamed', $this->reader->readMenu((int)$secondId)['title']);
+    }
+
+    /**
      * @magentoDataFixture Magento/Cms/_files/pages.php
      */
     public function testReadReturnsNullForAPageThatIsNotHyvaManaged(): void


### PR DESCRIPTION
Hyvä Menu Builder menus travel through git the way pages and blocks already do.

A menu has no native CMS row behind it, so it exports as a single json file rather than the html/json/hyva.json trio: `var/sync_cms_data/cms/menus/<identifier>---<stores>.json`, holding the whole record plus its `{theme, edition, css}` rows and the same diagnostic `references` list.

## Why there is no new CSS code

`MenuProvider` registers under the key `menu` in the provider pool that `JitCssRepository` reads, so `getAllThemeStyles()` and `saveStyles()` already address the menu tables. The existing edition ordering and UNIQUE-key handling apply unchanged.

## Two behaviours worth naming

**Matching.** The importer matches a menu by identifier within its own store scope, so a re-import updates rather than duplicates.

**`is_active`.** `MenuProvider::saveContent()` forces `setIsActive(true)` on publish. The importer writes the flag back afterwards, which is the menu equivalent of the `is_liveview_enabled` restore `writeFlags()` already does for pages. Without it an inactive menu returns enabled.

## Scope

- Menus stay out of `--type=all`, so an existing dump or import keeps writing and reading exactly the files it wrote before.
- Menu Builder is a separate composer package from Hyvä CMS, so availability is tracked separately. Both commands warn and do nothing when it is absent.
- Category links do not port: a menu item stores the identifier for a CMS page and the SKU for a product, but a category link and `hyva_menu_category_tree` store category IDs. Documented in the README.

## Verification

Exercised end to end against a real install with a 7-item menu:

- export produces the expected payload, store codes resolved from the assignment
- create path builds the row and its store link
- update path matches by identifier, no duplicate row
- `is_active=0` survives the import
- storefront still renders the menu after a full export/import cycle

Integration tests cover the absent path (reader and writer report unavailable, `readMenus()` returns `[]`, `writeMenu()` is a no-op, the export warns and writes nothing) and the present path (create-then-update round trip, skipped when Menu Builder is absent).