### PR TITLE
Export menu category links as url_path

### DIFF
--- a/Model/Service/HyvaCms/CategoryLinkMapper.php
+++ b/Model/Service/HyvaCms/CategoryLinkMapper.php
@@ -1,0 +1,261 @@
+<?php declare(strict_types=1);
+/*
+ * RocketWeb
+ *
+ *  NOTICE OF LICENSE
+ *
+ *  This source file is subject to the Open Software License (OSL 3.0)
+ *  that is bundled with this package in the file LICENSE.txt.
+ *  It is also available through the world-wide-web at this URL:
+ *  http://opensource.org/licenses/osl-3.0.php
+ *
+ *  @category  RocketWeb
+ *  @copyright Copyright (c) 2020 RocketWeb (http://rocketweb.com)
+ *  @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  @author    Rocket Web Inc.
+ */
+
+namespace RocketWeb\CmsImportExport\Model\Service\HyvaCms;
+
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
+
+/**
+ * Swaps category entity ids for url paths on the way out, and back again on the way in.
+ *
+ * A menu addresses a CMS page by identifier and a product by SKU, both of which mean the same thing on every
+ * install. A category link is the exception: it stores the entity id, and ids are assigned per environment, so
+ * an exported menu would point at whatever category happens to hold that id on the target.
+ *
+ * url_path is the key used here rather than name or url_key. Names collide freely, and Magento only enforces
+ * url_key uniqueness between siblings, so two branches can each hold "envelopes". url_path is the concatenation
+ * of the ancestor url keys, so it is unique by construction and still readable in a diff.
+ *
+ * Paths are read at the default store scope, because that is the value every store inherits unless it has been
+ * overridden, and a menu file is not store specific beyond the scope in its name.
+ *
+ * Anything that does not resolve is reported and left as it stands. That matches how a missing block or theme is
+ * handled elsewhere in this module: the import completes, and the warning says what will not render.
+ */
+class CategoryLinkMapper
+{
+    private const LINK_TYPE_KEY = 'type';
+    private const LINK_TYPE_CATEGORY = 'category';
+    private const LINK_VALUE_KEY = 'value';
+    private const CATEGORY_TREE_IDS_KEY = 'category_ids';
+    private const ROOT_KEYS = ['content', 'store_content'];
+    private const MAX_DEPTH = 100;
+
+    /**
+     * @var array<int, string>|null
+     */
+    private ?array $pathById = null;
+
+    /**
+     * @var array<string, int>|null
+     */
+    private ?array $idByPath = null;
+
+    public function __construct(
+        private readonly CollectionFactory $categoryCollectionFactory
+    ) {
+    }
+
+    /**
+     * Export direction: every category id becomes its url path.
+     *
+     * @param string|null $contentJson
+     * @param array<int, string> $warnings collected by reference, one line per id that has no category
+     * @return string|null the rewritten json, or the input unchanged when there is nothing to rewrite
+     */
+    public function idsToPaths(?string $contentJson, array &$warnings): ?string
+    {
+        return $this->rewrite($contentJson, $warnings, true);
+    }
+
+    /**
+     * Import direction: every url path becomes the local category id.
+     *
+     * @param string|null $contentJson
+     * @param array<int, string> $warnings collected by reference, one line per path this install does not have
+     * @return string|null the rewritten json, or the input unchanged when there is nothing to rewrite
+     */
+    public function pathsToIds(?string $contentJson, array &$warnings): ?string
+    {
+        return $this->rewrite($contentJson, $warnings, false);
+    }
+
+    /**
+     * @param array<int, string> $warnings
+     */
+    private function rewrite(?string $contentJson, array &$warnings, bool $toPaths): ?string
+    {
+        if ($contentJson === null || $contentJson === '') {
+            return $contentJson;
+        }
+
+        $content = json_decode($contentJson, true);
+        if (!is_array($content)) {
+            return $contentJson;
+        }
+
+        $changed = false;
+        foreach (self::ROOT_KEYS as $rootKey) {
+            if (!isset($content[$rootKey]) || !is_array($content[$rootKey])) {
+                continue;
+            }
+
+            $content[$rootKey] = $this->walk($content[$rootKey], $warnings, $toPaths, $changed, 0);
+        }
+
+        if (!$changed) {
+            return $contentJson;
+        }
+
+        return json_encode($content, JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     * @param array<int, string> $warnings
+     * @return array<array-key, mixed>
+     */
+    private function walk(array $node, array &$warnings, bool $toPaths, bool &$changed, int $depth): array
+    {
+        if ($depth >= self::MAX_DEPTH) {
+            return $node;
+        }
+
+        if ($this->isCategoryLink($node)) {
+            $mapped = $this->mapOne((string)$node[self::LINK_VALUE_KEY], $warnings, $toPaths);
+            if ($mapped !== null) {
+                $node[self::LINK_VALUE_KEY] = $mapped;
+                $changed = true;
+            }
+
+            return $node;
+        }
+
+        if (isset($node[self::CATEGORY_TREE_IDS_KEY]) && is_string($node[self::CATEGORY_TREE_IDS_KEY])) {
+            $mapped = $this->mapList($node[self::CATEGORY_TREE_IDS_KEY], $warnings, $toPaths);
+            if ($mapped !== null) {
+                $node[self::CATEGORY_TREE_IDS_KEY] = $mapped;
+                $changed = true;
+            }
+        }
+
+        foreach ($node as $key => $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+
+            $node[$key] = $this->walk($value, $warnings, $toPaths, $changed, $depth + 1);
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     */
+    private function isCategoryLink(array $node): bool
+    {
+        return ($node[self::LINK_TYPE_KEY] ?? null) === self::LINK_TYPE_CATEGORY
+            && isset($node[self::LINK_VALUE_KEY])
+            && (is_string($node[self::LINK_VALUE_KEY]) || is_int($node[self::LINK_VALUE_KEY]));
+    }
+
+    /**
+     * The comma separated list a category tree component stores. A list is rewritten whole or not at all, so that
+     * a partial failure cannot silently drop entries from a tree.
+     *
+     * @param array<int, string> $warnings
+     */
+    private function mapList(string $value, array &$warnings, bool $toPaths): ?string
+    {
+        $mapped = [];
+        foreach (explode(',', $value) as $item) {
+            $item = trim($item);
+            if ($item === '') {
+                continue;
+            }
+
+            $one = $this->mapOne($item, $warnings, $toPaths);
+            if ($one === null) {
+                return null;
+            }
+
+            $mapped[] = $one;
+        }
+
+        return $mapped === [] ? null : implode(',', $mapped);
+    }
+
+    /**
+     * @param array<int, string> $warnings
+     */
+    private function mapOne(string $value, array &$warnings, bool $toPaths): ?string
+    {
+        if ($toPaths) {
+            $path = $this->getPathById()[(int)$value] ?? null;
+            if ($path === null) {
+                $warnings[] = sprintf('category link %s has no category on this install, left as it is', $value);
+                return null;
+            }
+
+            return $path;
+        }
+
+        $id = $this->getIdByPath()[$value] ?? null;
+        if ($id === null) {
+            $warnings[] = sprintf('category path "%s" does not exist on this install, left as it is', $value);
+            return null;
+        }
+
+        return (string)$id;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getPathById(): array
+    {
+        if ($this->pathById === null) {
+            $this->loadCategories();
+        }
+
+        return $this->pathById;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getIdByPath(): array
+    {
+        if ($this->idByPath === null) {
+            $this->loadCategories();
+        }
+
+        return $this->idByPath;
+    }
+
+    private function loadCategories(): void
+    {
+        $this->pathById = [];
+        $this->idByPath = [];
+
+        $collection = $this->categoryCollectionFactory->create();
+        $collection->setStoreId(0);
+        $collection->addAttributeToSelect('url_path');
+
+        foreach ($collection as $category) {
+            $path = $category->getData('url_path');
+            if (!is_string($path) || $path === '') {
+                continue;
+            }
+
+            $id = (int)$category->getId();
+            $this->pathById[$id] = $path;
+            $this->idByPath[$path] = $id;
+        }
+    }
+}

--- a/Model/Service/HyvaCms/ContentReader.php
+++ b/Model/Service/HyvaCms/ContentReader.php
@@ -63,7 +63,8 @@ class ContentReader
     public function __construct(
         \Magento\Framework\ObjectManagerInterface $objectManager,
         private readonly \RocketWeb\CmsImportExport\Model\Service\HyvaCms\ReferenceCollector $referenceCollector,
-        private readonly \Magento\Framework\Api\SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
+        private readonly \Magento\Framework\Api\SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory,
+        private readonly \RocketWeb\CmsImportExport\Model\Service\HyvaCms\CategoryLinkMapper $categoryLinkMapper
     ) {
         $hyvaCmsInstalled = interface_exists(self::PAGE_REPOSITORY)
             && interface_exists(self::BLOCK_REPOSITORY)
@@ -173,8 +174,13 @@ class ContentReader
      */
     private function buildMenuContent(object $menu): array
     {
-        $draftContent = $menu->getDraftContent();
-        $publishedContent = $menu->getPublishedContent();
+        $warnings = [];
+        $draftContent = $this->categoryLinkMapper->idsToPaths($menu->getDraftContent(), $warnings);
+        $publishedContent = $this->categoryLinkMapper->idsToPaths($menu->getPublishedContent(), $warnings);
+
+        foreach (array_unique($warnings) as $warning) {
+            echo sprintf('menu "%s": %s%s', (string)$menu->getIdentifier(), $warning, PHP_EOL);
+        }
 
         return [
             'title' => $menu->getTitle(),

--- a/Model/Service/HyvaCms/ContentWriter.php
+++ b/Model/Service/HyvaCms/ContentWriter.php
@@ -78,7 +78,8 @@ class ContentWriter
     private readonly ?object $menuFactory;
 
     public function __construct(
-        \Magento\Framework\ObjectManagerInterface $objectManager
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        private readonly \RocketWeb\CmsImportExport\Model\Service\HyvaCms\CategoryLinkMapper $categoryLinkMapper
     ) {
         $hyvaCmsInstalled = interface_exists(self::PAGE_REPOSITORY)
             && interface_exists(self::BLOCK_REPOSITORY)
@@ -175,13 +176,23 @@ class ContentWriter
      * @param int $menuId the id of the menu row the importer just saved
      * @param array<string, mixed> $payload the decoded menu json file
      */
-    public function writeMenu(int $menuId, array $payload): void
+    public function writeMenu(int $menuId, array $payload, array &$warnings = []): void
     {
         if (!$this->isMenuAvailable()) {
             return;
         }
 
         $tailwindcss = $payload['tailwindcss'] ?? [];
+
+        foreach (['draft_content', 'published_content'] as $key) {
+            if (!isset($payload[$key]) || !is_string($payload[$key])) {
+                continue;
+            }
+
+            $payload[$key] = $this->categoryLinkMapper->pathsToIds($payload[$key], $warnings);
+        }
+
+        $warnings = array_values(array_unique($warnings));
 
         $this->writeContent(self::ENTITY_TYPE_MENU, $menuId, $payload);
         $this->writeTailwindcss(self::ENTITY_TYPE_MENU, $menuId, is_array($tailwindcss) ? $tailwindcss : []);

--- a/Model/Service/ImportCmsDataService.php
+++ b/Model/Service/ImportCmsDataService.php
@@ -174,12 +174,17 @@ class ImportCmsDataService
             }
 
             $storeIds = $this->getStoreIds($payload['stores'] ?? []);
+            $categoryWarnings = [];
             try {
                 $menuId = $this->hyvaContentWriter->saveMenuRow($payload, $storeIds);
-                $this->hyvaContentWriter->writeMenu((int)$menuId, $payload);
+                $this->hyvaContentWriter->writeMenu((int)$menuId, $payload, $categoryWarnings);
             } catch (\Exception $exception) {
                 $this->warnHyva(sprintf('%s could not be written: %s', $entityLabel, $exception->getMessage()));
                 continue;
+            }
+
+            foreach ($categoryWarnings as $warning) {
+                $this->warnHyva(sprintf('%s: %s', $entityLabel, $warning));
             }
 
             foreach ($this->hyvaPayloadValidator->validate($entityLabel, $payload) as $warning) {

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ nothing. `--hyva-cms` has no meaning here, because the Hyva content is the whole
 Watch out for:
 
 - **`--type=all` does not include menus.** Ask for them explicitly.
-- **Category links do not survive the trip.** A menu item stores the identifier for a CMS page and the
-  SKU for a product, but a category link and `hyva_menu_category_tree` store category IDs.
+- **Category links export as `url_path`, not as an entity id**, so they resolve on the target. That covers
+  a `category` link and `hyva_menu_category_tree`. A path the target does not have is reported and left
+  alone, so the link renders as nothing until the category exists.
 - A menu matches by identifier within its own store scope, so a re-import updates rather than duplicates.
 - Pointing a storefront at the menu is separate configuration, `design/header/topmenu_identifier`.

--- a/Test/Integration/HyvaCms/CategoryLinkMapperTest.php
+++ b/Test/Integration/HyvaCms/CategoryLinkMapperTest.php
@@ -110,16 +110,14 @@ class CategoryLinkMapperTest extends TestCase
     }
 
     /**
-     * The fixture sets no url key, and url_path generation depends on rewrite observers that this suite has no
-     * reason to rely on, so the value under test is written explicitly.
+     * url_path is generated from the category name, and setting it explicitly does not stick because the url
+     * path autogenerator overwrites it on save. The generated value is read instead, and only its presence is
+     * asserted: what matters here is the round trip, not which slug Magento picked.
      */
     private function givenCategoryUrlPath(int $categoryId): string
     {
-        $urlPath = 'rw-mapper-test-category';
-        $category = $this->categoryRepository->get($categoryId);
-        $category->setData('url_key', $urlPath);
-        $category->setData('url_path', $urlPath);
-        $this->categoryRepository->save($category);
+        $urlPath = (string)$this->categoryRepository->get($categoryId)->getData('url_path');
+        $this->assertNotSame('', $urlPath, 'The fixture category needs a url_path for this test to mean anything.');
 
         return $urlPath;
     }

--- a/Test/Integration/HyvaCms/CategoryLinkMapperTest.php
+++ b/Test/Integration/HyvaCms/CategoryLinkMapperTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RocketWeb\CmsImportExport\Test\Integration\HyvaCms;
+
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+use RocketWeb\CmsImportExport\Model\Service\HyvaCms\CategoryLinkMapper;
+
+/**
+ * Category ids are assigned per environment, so a menu that stores one points at a different category after an
+ * import. These tests pin the swap to url_path and the reporting of anything that does not resolve.
+ *
+ * The mapper is plain catalog code with no Hyva dependency, so this suite runs everywhere rather than skipping
+ * on an install without Hyva CMS.
+ *
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class CategoryLinkMapperTest extends TestCase
+{
+    private ?CategoryLinkMapper $mapper = null;
+    private ?CategoryRepositoryInterface $categoryRepository = null;
+
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->mapper = $objectManager->create(CategoryLinkMapper::class);
+        $this->categoryRepository = $objectManager->create(CategoryRepositoryInterface::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/category.php
+     */
+    public function testCategoryLinkRoundTripsThroughItsUrlPath(): void
+    {
+        $categoryId = 333;
+        $urlPath = $this->givenCategoryUrlPath($categoryId);
+
+        $content = $this->buildContent(['type' => 'category', 'value' => (string)$categoryId]);
+
+        $warnings = [];
+        $exported = $this->mapper->idsToPaths($content, $warnings);
+        $this->assertSame([], $warnings);
+        $this->assertSame($urlPath, $this->getLinkValue($exported));
+
+        $warnings = [];
+        $imported = $this->mapper->pathsToIds($exported, $warnings);
+        $this->assertSame([], $warnings);
+        $this->assertSame((string)$categoryId, $this->getLinkValue($imported));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/category.php
+     */
+    public function testCategoryTreeIdsRoundTrip(): void
+    {
+        $categoryId = 333;
+        $urlPath = $this->givenCategoryUrlPath($categoryId);
+
+        $content = json_encode([
+            'content' => [
+                ['uid' => 'tree', 'component' => 'hyva_menu_category_tree', 'category_ids' => (string)$categoryId]
+            ]
+        ]);
+
+        $warnings = [];
+        $exported = $this->mapper->idsToPaths($content, $warnings);
+        $this->assertStringContainsString($urlPath, (string)$exported);
+
+        $imported = json_decode((string)$this->mapper->pathsToIds($exported, $warnings), true);
+        $this->assertSame((string)$categoryId, $imported['content'][0]['category_ids']);
+    }
+
+    public function testUnknownPathIsReportedAndLeftAlone(): void
+    {
+        $content = $this->buildContent(['type' => 'category', 'value' => 'no/such/category']);
+
+        $warnings = [];
+        $result = $this->mapper->pathsToIds($content, $warnings);
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('no/such/category', $warnings[0]);
+        $this->assertSame('no/such/category', $this->getLinkValue($result));
+    }
+
+    /**
+     * A CMS page link already carries a portable identifier, so it has to come through untouched.
+     */
+    public function testNonCategoryLinksAreNotRewritten(): void
+    {
+        $content = $this->buildContent(['type' => 'cms_page', 'value' => 'about-us']);
+
+        $warnings = [];
+        $this->assertSame($content, $this->mapper->idsToPaths($content, $warnings));
+        $this->assertSame($content, $this->mapper->pathsToIds($content, $warnings));
+        $this->assertSame([], $warnings);
+    }
+
+    public function testEmptyContentIsReturnedUnchanged(): void
+    {
+        $warnings = [];
+
+        $this->assertNull($this->mapper->idsToPaths(null, $warnings));
+        $this->assertSame('', $this->mapper->pathsToIds('', $warnings));
+        $this->assertSame('not json', $this->mapper->idsToPaths('not json', $warnings));
+        $this->assertSame([], $warnings);
+    }
+
+    /**
+     * The fixture sets no url key, and url_path generation depends on rewrite observers that this suite has no
+     * reason to rely on, so the value under test is written explicitly.
+     */
+    private function givenCategoryUrlPath(int $categoryId): string
+    {
+        $urlPath = 'rw-mapper-test-category';
+        $category = $this->categoryRepository->get($categoryId);
+        $category->setData('url_key', $urlPath);
+        $category->setData('url_path', $urlPath);
+        $this->categoryRepository->save($category);
+
+        return $urlPath;
+    }
+
+    /**
+     * @param array<string, string> $link
+     */
+    private function buildContent(array $link): string
+    {
+        return (string)json_encode([
+            'content' => [
+                ['uid' => 'item', 'component' => 'hyva_menu_item', 'link' => $link]
+            ]
+        ]);
+    }
+
+    private function getLinkValue(?string $contentJson): ?string
+    {
+        return json_decode((string)$contentJson, true)['content'][0]['link']['value'] ?? null;
+    }
+}


### PR DESCRIPTION
Follow-up to #14. A menu addresses a CMS page by identifier and a product by SKU, both portable. A category link was the exception: it stores the entity id, so an exported menu pointed at whatever category held that id on the target.

`CategoryLinkMapper` swaps the id for `url_path` on export and back on import, covering both a `category` link and the `category_ids` list of `hyva_menu_category_tree`.

## Why url_path

Measured on a real 288-category catalog:

| key | rows | distinct |
|---|---|---|
| `name` | 288 | 247 |
| `url_key` | 287 | 287 |
| `url_path` | 286 (1 null) | 285 |

`name` collides 41 times, so it is unusable. `url_key` is unique on that catalog by luck — Magento only enforces it between siblings, so two branches can each hold `envelopes`. `url_path` is the concatenation of the ancestor url keys, unique by construction and still readable in a diff.

Paths are read at the default store scope, which is what every store inherits unless overridden.

## Failure handling

Anything that does not resolve is reported and left as it stands, matching how a missing block or theme is already handled: the import completes and the warning says what will not render.

A category tree list is rewritten whole or not at all, so a partial failure cannot silently drop entries from a tree.

## Scope

Menus only. Pages and blocks can carry the same links, but they keep the behaviour they shipped with until that is asked for.

## Verification

Against a real install, with a category link (id 147) and a category tree (`148,149`) added to a live menu:

- export wrote `product-category/amsive-miamisburg` and `product-category/state-wisconsin-employee-trust,product-category/state-wisconsin-uw-green-bay`
- import resolved them back to `147` and `148,149`
- a hand-broken path produced `category path "product-category/does-not-exist-here" does not exist on this install, left as it is` and the import completed

Integration tests cover the round trip for a link and for a tree, an unknown path, a non-category link passing through untouched, and empty or non-json content.